### PR TITLE
Convert the name length to an int before using it

### DIFF
--- a/jbt.py
+++ b/jbt.py
@@ -85,7 +85,7 @@ def jit_break (frame, bp_loc, dic):
     length_var = frame.FindVariable('length')
 
     length      = length_var.GetValueAsUnsigned()
-    name        = "%.*s" % (length, name_var.GetSummary().strip('"'))
+    name        = "%.*s" % (int(length), name_var.GetSummary().strip('"'))
     code        = code_var.GetValueAsUnsigned()
     inst_start  = code + kHeaderSize
     


### PR DESCRIPTION
In some cases, GetValueAsUnsigned returns a long instead of an int.
Python's string formatting is strongly opposed to longs or something.
